### PR TITLE
ixml (and xproc) for onepiece

### DIFF
--- a/Class-Examples/ixml/onepiece/onepiece.xpl
+++ b/Class-Examples/ixml/onepiece/onepiece.xpl
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc" exclude-inline-prefixes="#all"
+    xmlns:c="http://www.w3.org/ns/xproc-step" xmlns:cx="http://xmlcalabash.com/ns/extensions"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ex="extensions" version="3.0">
+    <!-- ================================================================ -->
+    <!-- Housekeeping-->
+    <!-- ================================================================ -->
+    <p:input primary="true" port="source" content-types="text" href="source/vol-4.txt"/>
+    <p:output primary="true" port="result"/>
+    <!-- ================================================================ -->
+    <!-- Working steps                                                    -->
+    <!-- ================================================================ -->
+    <p:invisible-xml>
+        <p:with-input port="grammar">
+            <p:document href="tag-chapters.ixml" content-type="text/plain"/>
+        </p:with-input>
+    </p:invisible-xml>
+    <p:identity/>
+</p:declare-step>

--- a/Class-Examples/ixml/onepiece/onepiece.xpl
+++ b/Class-Examples/ixml/onepiece/onepiece.xpl
@@ -5,15 +5,28 @@
     <!-- ================================================================ -->
     <!-- Housekeeping-->
     <!-- ================================================================ -->
-    <p:input primary="true" port="source" content-types="text" href="source/vol-4.txt"/>
-    <p:output primary="true" port="result"/>
+    <p:input primary="true" sequence="false" port="source" content-types="text"
+        href="source/vol-4.txt"/>
+    <p:output primary="true" sequence="false" port="result" serialization="map {
+            'method' : 'xml',
+            'indent' : true()
+        }"/>
     <!-- ================================================================ -->
     <!-- Working steps                                                    -->
+    <!-- ================================================================ -->
+    <!-- Add basic XML markup, including chapter divisions                -->
+    <!-- Distinguish chapter header lines from other chapter lines        -->
+    <!-- No distinction yet between speech and aside ("extra stuff")      -->
     <!-- ================================================================ -->
     <p:invisible-xml>
         <p:with-input port="grammar">
             <p:document href="tag-chapters.ixml" content-type="text/plain"/>
         </p:with-input>
     </p:invisible-xml>
-    <p:identity/>
+    <!-- ================================================================ -->
+    <!-- Distinguish <sp> from <aside>, tag both                          -->
+    <!-- ================================================================ -->
+    <p:xslt>
+        <p:with-input port="stylesheet" href="tag-speech.xsl"/>
+    </p:xslt>
 </p:declare-step>

--- a/Class-Examples/ixml/onepiece/tag-chapters.ixml
+++ b/Class-Examples/ixml/onepiece/tag-chapters.ixml
@@ -2,7 +2,22 @@ volume: -"SBS Volume ", num, newline, newline, body.
 @num: digits.
 body: (chapter-head-line; chapter-body-line)++newline.
 chapter-head-line: -"Chapter ", num, -", Page ", page.
-chapter-body-line: ~["Chapter "], ~[#d;#a]+.
-@page: digits.
+{
+    dialogue-line begins with single upper-case letter followed by colon and space
+    non-dialogue-line begins with anything except the preceding or the string "Chapter "
+    check for string in non-dialogue line by excluding, in an or-group, initial "C",
+        second character "h", third character "a", etc.
+    Thanks to Bethan Tovey-Walsh for the non-chapter suggestion
+}
+chapter-body-line = 
+    ~["C"], ~[#d;#a]* |
+    "C", (~["h"], ~[#d;#a]* |
+        "h", (~["a"], ~[#d;#a]* | 
+            "a", (~["p"], ~[#d;#a]* | 
+                "p", (~["t"], ~[#d;#a]* | 
+                    "t", (~["e"], ~[#d;#a]* | 
+                        "e", (~["r"], ~[#d;#a]* | 
+                            "r", ~[" "], ~[#d;#a]+)))))).
+page: digits.
 -digits: ["0"-"9"]+.
 -newline: -#d?, #a.

--- a/Class-Examples/ixml/onepiece/tag-chapters.ixml
+++ b/Class-Examples/ixml/onepiece/tag-chapters.ixml
@@ -1,0 +1,8 @@
+volume: -"SBS Volume ", num, newline, newline, body.
+@num: digits.
+body: (chapter-head-line; chapter-body-line)++newline.
+chapter-head-line: -"Chapter ", num, -", Page ", page.
+chapter-body-line: ~["Chapter "], ~[#d;#a]+.
+@page: digits.
+-digits: ["0"-"9"]+.
+-newline: -#d?, #a.

--- a/Class-Examples/ixml/onepiece/tag-chapters.ixml
+++ b/Class-Examples/ixml/onepiece/tag-chapters.ixml
@@ -1,23 +1,19 @@
-volume: -"SBS Volume ", num, newline, newline, body.
+volume: -"SBS Volume ", num, newline+, body.
 @num: digits.
-body: (chapter-head-line; chapter-body-line)++newline.
+body: chapter++(newline, newline).
+chapter: chapter-head-line, newline+, chapter-body-line++(newline+).
 chapter-head-line: -"Chapter ", num, -", Page ", page.
-{
-    dialogue-line begins with single upper-case letter followed by colon and space
-    non-dialogue-line begins with anything except the preceding or the string "Chapter "
-    check for string in non-dialogue line by excluding, in an or-group, initial "C",
-        second character "h", third character "a", etc.
-    Thanks to Bethan Tovey-Walsh for the non-chapter suggestion
-}
+{ Thanks to Bethan Tovey-Walsh for the non-chapter-head suggestion }
 chapter-body-line = 
-    ~["C"], ~[#d;#a]* |
-    "C", (~["h"], ~[#d;#a]* |
-        "h", (~["a"], ~[#d;#a]* | 
-            "a", (~["p"], ~[#d;#a]* | 
-                "p", (~["t"], ~[#d;#a]* | 
-                    "t", (~["e"], ~[#d;#a]* | 
-                        "e", (~["r"], ~[#d;#a]* | 
-                            "r", ~[" "], ~[#d;#a]+)))))).
-page: digits.
+    ~["C";#d;#a], linechar* |
+    "C", (~["h"], linechar* |
+        "h", (~["a"], linechar* | 
+            "a", (~["p"], linechar* | 
+                "p", (~["t"], linechar* | 
+                    "t", (~["e"], linechar* | 
+                        "e", (~["r"], linechar* | 
+                            "r", ~[" "], linechar*)))))).
+@page: digits.
 -digits: ["0"-"9"]+.
 -newline: -#d?, #a.
+-linechar: ~[#d; #a].

--- a/Class-Examples/ixml/onepiece/tag-speech.xsl
+++ b/Class-Examples/ixml/onepiece/tag-speech.xsl
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:math="http://www.w3.org/2005/xpath-functions/math" exclude-result-prefixes="#all"
+    version="3.0">
+    <xsl:mode on-no-match="shallow-copy"/>
+    <xsl:template match="chapter">
+        <xsl:copy>
+            <xsl:copy-of select="chapter-head-line/@*"/>
+            <xsl:apply-templates select="chapter-body-line"/>
+        </xsl:copy>
+    </xsl:template>
+    <xsl:template match="chapter-body-line">
+        <xsl:choose>
+            <xsl:when test="matches(., '^[A-Z]:')">
+                <sp speaker="{substring(., 1, 1)}">
+                    <xsl:value-of select="substring(., 2)"/>
+                </sp>
+            </xsl:when>
+            <xsl:otherwise>
+                <aside>
+                    <xsl:value-of select="."/>
+                </aside>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+</xsl:stylesheet>

--- a/textAnalysis-Hub.xpr
+++ b/textAnalysis-Hub.xpr
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <meta>
+        <filters directoryPatterns="" filePatterns="\QtextAnalysis-Hub.xpr\E" positiveFilePatterns="" showHiddenFiles="false"/>
+        <options/>
+    </meta>
+    <projectTree name="textAnalysis-Hub.xpr">
+        <folder path="."/>
+    </projectTree>
+</project>


### PR DESCRIPTION
This PR adds code to process _onepiece/source/vol-4.txt_. You can run the full pipeline with either XML Calabash (using either Markup Blitz or the default CoffeePot for the ixml step) or Morgana:

- xmlcalabash onepiece.xpl
- morgana onepiece.xpl

Alternatively, you can run just the ixml step with CoffeePot, Markup Blitz, or xmq:

- coffeepot -g:tag-chapters.ixml -i:source/vol-4.txt
- blitz tag-chapters.ixml source/vol-4.txt
- xmq --ixml=tag-chapters.ixml source/vol-4.txt to-xml